### PR TITLE
Update to the latest libvterm.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libvterm"]
+	path = libvterm
+	url = git@github.com:neovim/libvterm.git

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+libvterm.a: libvterm
+	cd libvterm && \
+	CFLAGS="-O3 -fstack-protector-strong -march=x86-64 -mtune=generic" DEBUG=0 make && \
+	cd .. && \
+	cp ./libvterm/.libs/libvterm.a .
+	strip --strip-unneeded --strip-debug ./libvterm.a
+
+clean:
+	cd libvterm && \
+	make clean && \
+	cd .. && \
+	rm -f libvterm.a

--- a/_example/color/main.go
+++ b/_example/color/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	screen := vt.ObtainScreen()
 	screen.Reset(true)
+	state := vt.ObtainState()
 
 	_, err := vt.Write([]byte("\033[31mHello \033[32mGolang\033[0m"))
 	if err != nil {
@@ -52,7 +53,7 @@ func main() {
 			}
 			chars := cell.Chars()
 			if len(chars) > 0 && chars[0] != 0 {
-				drawChar(img, (col+1)*7, (row+1)*13, cell.Fg(), string(chars))
+				drawChar(img, (col+1)*7, (row+1)*13, state.ConvertVTermColorToRGB(cell.Fg()), string(chars))
 			}
 		}
 	}

--- a/vterm.go
+++ b/vterm.go
@@ -1,8 +1,8 @@
 package vterm
 
 /*
-#cgo CFLAGS: -I./libvterm/include
-#cgo LDFLAGS: ./libvterm.a
+#cgo CFLAGS: -I${SRCDIR}/libvterm/include
+#cgo LDFLAGS: ${SRCDIR}/libvterm.a
 #include <vterm.h>
 
 inline static int _attr_bold(VTermScreenCell *cell) { return cell->attrs.bold; }

--- a/vterm.go
+++ b/vterm.go
@@ -1,8 +1,9 @@
 package vterm
 
 /*
+#cgo CFLAGS: -I./libvterm/include
+#cgo LDFLAGS: ./libvterm.a
 #include <vterm.h>
-#cgo pkg-config: vterm
 
 inline static int _attr_bold(VTermScreenCell *cell) { return cell->attrs.bold; }
 inline static int _attr_underline(VTermScreenCell *cell) { return cell->attrs.underline; }

--- a/vterm.go
+++ b/vterm.go
@@ -133,12 +133,55 @@ type ParserCallbacks struct {
 	*/
 }
 
-func toCVtermColor(col color.RGBA) *C.VTermColor {
-	return &C.VTermColor{C.uint8_t(col.R), C.uint8_t(col.G), C.uint8_t(col.B)}
+// To get the rgb value from a VTermColor instance, call state.ConvertVTermColorToRGB
+type VTermColor struct {
+	color C.VTermColor
 }
 
-func colorFromVTermColor(vtcol *C.VTermColor) color.RGBA {
-	return color.RGBA{R: uint8(vtcol.red), G: uint8(vtcol.green), B: uint8(vtcol.blue), A: 255}
+func NewVTermColorRGB(col color.Color) VTermColor {
+	var r, g, b uint8
+	colRGBA, ok := col.(color.RGBA)
+	if ok {
+		r, g, b = colRGBA.R, colRGBA.G, colRGBA.B
+	} else {
+		r16, g16, b16, _ := col.RGBA()
+		r = uint8(r16 >> 8)
+		g = uint8(g16 >> 8)
+		b = uint8(b16 >> 8)
+	}
+	var t C.VTermColor
+	C.vterm_color_rgb(&t, C.uchar(r), C.uchar(g), C.uchar(b))
+	return VTermColor{t}
+}
+
+func NewVTermColorIndexed(index uint8) VTermColor {
+	var t C.VTermColor
+	t[0] |= 1
+	t[1] = index
+	return VTermColor{t}
+}
+
+func (c *VTermColor) IsIndex() bool {
+	return c.color[0]&1 > 0
+}
+func (c *VTermColor) IsRGB() bool {
+	return c.color[0]&1 == 0
+}
+
+func (c *VTermColor) GetRGB() (r, g, b uint8, ok bool) {
+	if c.IsRGB() {
+		return uint8(c.color[1]), uint8(c.color[2]), uint8(c.color[3]), true
+	} else {
+		return 0, 0, 0, false
+	}
+}
+
+func (c *VTermColor) GetIndex() (index uint8, ok bool) {
+	if c.IsIndex() {
+		return uint8(c.color[1]), true
+	} else {
+		return 0, false
+	}
 }
 
 func (sc *ScreenCell) Chars() []rune {
@@ -153,12 +196,12 @@ func (sc *ScreenCell) Width() int {
 	return int(sc.cell.width)
 }
 
-func (sc *ScreenCell) Fg() color.Color {
-	return colorFromVTermColor(&sc.cell.fg)
+func (sc *ScreenCell) Fg() VTermColor {
+	return VTermColor{sc.cell.fg}
 }
 
-func (sc *ScreenCell) Bg() color.Color {
-	return colorFromVTermColor(&sc.cell.bg)
+func (sc *ScreenCell) Bg() VTermColor {
+	return VTermColor{sc.cell.bg}
 }
 
 type Attrs struct {
@@ -226,37 +269,6 @@ func (vt *VTerm) ObtainState() *State {
 	return &State{
 		state: C.vterm_obtain_state(vt.term),
 	}
-}
-
-func (s *State) SetDefaultColors(fg, bg color.RGBA) {
-	C.vterm_state_set_default_colors(s.state, toCVtermColor(fg), toCVtermColor(bg))
-}
-
-// index between 0 and 15, 0-7 are normal colors and 8-15 are bright colors.
-func (s *State) SetPaletteColor(index int, col color.RGBA) {
-	if index < 0 || index >= 16 {
-		panic("Index out of range")
-	}
-	C.vterm_state_set_palette_color(s.state, C.int(index), toCVtermColor(col))
-}
-
-func (s *State) GetDefaultColors() (fg, bg color.RGBA) {
-	vt_fg := &C.VTermColor{}
-	vt_bg := &C.VTermColor{}
-	C.vterm_state_get_default_colors(s.state, vt_fg, vt_bg)
-	fg = colorFromVTermColor(vt_fg)
-	bg = colorFromVTermColor(vt_bg)
-	return
-}
-
-// index between 0 and 15, 0-7 are normal colors and 8-15 are bright colors.
-func (s *State) GetPaletteColor(index int) color.RGBA {
-	if index < 0 || index >= 16 {
-		panic("Index out of range")
-	}
-	vt_c := &C.VTermColor{}
-	C.vterm_state_get_palette_color(s.state, C.int(index), vt_c)
-	return colorFromVTermColor(vt_c)
 }
 
 func (vt *VTerm) Read(b []byte) (int, error) {
@@ -353,6 +365,47 @@ func (scr *Screen) IsEOL(pos *Pos) bool {
 
 type State struct {
 	state *C.VTermState
+}
+
+func (s *State) ConvertVTermColorToRGB(col VTermColor) color.RGBA {
+	if col.IsRGB() {
+		arr := col.color
+		return color.RGBA{uint8(arr[1]), uint8(arr[2]), uint8(arr[3]), 255}
+	}
+	cColor := col.color
+	C.vterm_state_convert_color_to_rgb(s.state, &cColor)
+	return color.RGBA{uint8(cColor[1]), uint8(cColor[2]), uint8(cColor[3]), 255}
+}
+
+func (s *State) SetDefaultColors(fg, bg VTermColor) {
+	C.vterm_state_set_default_colors(s.state, &fg.color, &bg.color)
+}
+
+// index between 0 and 15, 0-7 are normal colors and 8-15 are bright colors.
+func (s *State) SetPaletteColor(index int, col VTermColor) {
+	if index < 0 || index >= 16 {
+		panic("Index out of range")
+	}
+	C.vterm_state_set_palette_color(s.state, C.int(index), &col.color)
+}
+
+func (s *State) GetDefaultColors() (fg, bg VTermColor) {
+	c_fg := C.VTermColor{}
+	c_bg := C.VTermColor{}
+	C.vterm_state_get_default_colors(s.state, &c_fg, &c_bg)
+	fg = VTermColor{c_fg}
+	bg = VTermColor{c_bg}
+	return
+}
+
+// index between 0 and 15, 0-7 are normal colors and 8-15 are bright colors.
+func (s *State) GetPaletteColor(index int) VTermColor {
+	if index < 0 || index >= 16 {
+		panic("Index out of range")
+	}
+	c_color := C.VTermColor{}
+	C.vterm_state_get_palette_color(s.state, C.int(index), &c_color)
+	return VTermColor{c_color}
 }
 
 //export _go_handle_damage


### PR DESCRIPTION
This pull request does several things:

- It exposes API for the new union type `VTermColor`, introduced in [`26c3468`](https://github.com/neovim/libvterm/commit/26c3468c51d1c8f1a26aa1252783b04845ccc9f9).
- It adds `neovim/libvterm` as a submodule of this package.

The reason for the second point is that the version of libvterm package on most system is likely to not be the latest, and may actually differs a lot. Also, the latest commit at `neovim/libvterm` makes new things possible. Therefore (I think) it would make sense for this package to include a copy of the library and build with that.

However, I don't know a way of specifying things to do when Go is building the library, such as running a `Makefile`, nor do I know a way to make cgo compile libvterm. Therefore, if you think it is a good idea, you can run `make` and commit the binary to the package repo.

Ps. I'm currently using this package in my project [ts-player](https://github.com/micromaomao/ts-player).